### PR TITLE
chore: Update workflow to use --immutable option

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
           cache: yarn
 
       - name: Install dependencies
-        run: yarn install
+        run: yarn install --immutable
 
       - name: Lint
         run: yarn run lint


### PR DESCRIPTION
## Description

워크플로우에서 lock 파일을 기준으로 패키지를 설치하기 위해 `--immutable` option을 추가함.