### PR TITLE
refactor: Use meaningful theme names

### DIFF
--- a/themes/prism-github-default-auto.css
+++ b/themes/prism-github-default-auto.css
@@ -1,5 +1,5 @@
 /**
- * GitHub theme for prism.js
+ * GitHub's Default theme for prism.js
  * @author Jongwoo Han (@jongwooo)
  */
 

--- a/themes/prism-github-default-dark.css
+++ b/themes/prism-github-default-dark.css
@@ -1,19 +1,19 @@
 /**
- * GitHub Dimmed Dark theme for prism.js
+ * GitHub's Default Dark theme for prism.js
  * @author Jongwoo Han (@jongwooo)
  */
 
 :root {
-	--color-fg-default: #adbac7;
-	--color-bg-code-block: #2d333b;
-	--color-bg-inline-code-block: rgb(99 110 123 / 40%);
-	--color-gray: #768390;
-	--color-red: #f47067;
-	--color-green: #8ddb8c;
-	--color-blue: #96d0ff;
-	--color-indigo: #6cb6ff;
-	--color-purple: #dcbdfb;
-	--color-brown: #f69d50;
+	--color-fg-default: #c9d1d9;
+	--color-bg-code-block: #161b22;
+	--color-bg-inline-code-block: rgb(110 118 129 / 40%);
+	--color-gray: #8b949e;
+	--color-red: #ff7b72;
+	--color-green: #7ee787;
+	--color-blue: #79c0ff;
+	--color-indigo: #a5d6ff;
+	--color-purple: #d2a8ff;
+	--color-brown: #ffa657;
 }
 
 code[class*="language-"],

--- a/themes/prism-github-default-light.css
+++ b/themes/prism-github-default-light.css
@@ -1,19 +1,19 @@
 /**
- * GitHub Dark theme for prism.js
+ * GitHub's Default Light theme for prism.js
  * @author Jongwoo Han (@jongwooo)
  */
 
 :root {
-	--color-fg-default: #c9d1d9;
-	--color-bg-code-block: #161b22;
-	--color-bg-inline-code-block: rgb(110 118 129 / 40%);
-	--color-gray: #8b949e;
-	--color-red: #ff7b72;
-	--color-green: #7ee787;
-	--color-blue: #79c0ff;
-	--color-indigo: #a5d6ff;
-	--color-purple: #d2a8ff;
-	--color-brown: #ffa657;
+	--color-fg-default: #24292f;
+	--color-bg-code-block: #f6f8fa;
+	--color-bg-inline-code-block: rgb(175 184 193 / 20%);
+	--color-gray: #6e7781;
+	--color-red: #cf222e;
+	--color-green: #116329;
+	--color-blue: #0550ae;
+	--color-indigo: #0a3069;
+	--color-purple: #8250df;
+	--color-brown: #953800;
 }
 
 code[class*="language-"],

--- a/themes/prism-github-dimmed-dark.css
+++ b/themes/prism-github-dimmed-dark.css
@@ -1,19 +1,19 @@
 /**
- * GitHub Light theme for prism.js
+ * GitHub's Dimmed Dark theme for prism.js
  * @author Jongwoo Han (@jongwooo)
  */
 
 :root {
-	--color-fg-default: #24292f;
-	--color-bg-code-block: #f6f8fa;
-	--color-bg-inline-code-block: rgb(175 184 193 / 20%);
-	--color-gray: #6e7781;
-	--color-red: #cf222e;
-	--color-green: #116329;
-	--color-blue: #0550ae;
-	--color-indigo: #0a3069;
-	--color-purple: #8250df;
-	--color-brown: #953800;
+	--color-fg-default: #adbac7;
+	--color-bg-code-block: #2d333b;
+	--color-bg-inline-code-block: rgb(99 110 123 / 40%);
+	--color-gray: #768390;
+	--color-red: #f47067;
+	--color-green: #8ddb8c;
+	--color-blue: #96d0ff;
+	--color-indigo: #6cb6ff;
+	--color-purple: #dcbdfb;
+	--color-brown: #f69d50;
 }
 
 code[class*="language-"],


### PR DESCRIPTION
## Description

Use meaningful theme names.

- `themes/prism-github-all.css` -> `themes/prism-github-default-auto.css`
- `themes/prism-github-light.css` -> `themes/prism-github-default-light.css`
- `themes/prism-github-dark.css` -> `themes/prism-github-default-dark.css`
- `themes/prism-github-dark-dimmed.css` -> `themes/prism-github-dimmed-dark.css`