### PR TITLE
fix: Use media-feature-range-notation

### DIFF
--- a/themes/prism-github-skeleton.css
+++ b/themes/prism-github-skeleton.css
@@ -36,7 +36,7 @@ pre[class*="language-"] {
 	white-space: normal;
 }
 
-@media (max-width: 700px) {
+@media (width <= 700px) {
 	:not(pre) > code[class*="language-"] {
 		font-size: 0.875rem;
 	}


### PR DESCRIPTION
## Description

Fixes #38 

Use `media-feature-range-notation`. For more information, see https://stylelint.io/user-guide/rules/media-feature-range-notation/

**AS-IS**

```css
@media (max-width: 700px) {
	:not(pre) > code[class*="language-"] {
		font-size: 0.875rem;
	}
}
```

**TO-BE**

```css
@media (width <= 700px) {
	:not(pre) > code[class*="language-"] {
		font-size: 0.875rem;
	}
}
```